### PR TITLE
updating requirements and settings for celery

### DIFF
--- a/formspree/settings.py
+++ b/formspree/settings.py
@@ -52,4 +52,5 @@ CONTACT_FORM_HASHID = os.getenv('CONTACT_FORM_HASHID', CONTACT_EMAIL)
 
 TYPEKIT_KEY = os.getenv('TYPEKIT_KEY', '1234567')
 
-CELERY_BROKER_URL = os.getenv('REDIS_URL')
+CELERY_BROKER_URL = os.getenv('REDIS_URL') or 'redis://localhost:6379'
+CELERY_RESULT_BACKEND = os.getenv('REDIS_URL') or 'redis://localhost:6379'

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ MarkupSafe==0.23
 mock==2.0.0
 Paste==2.0.3
 pbr==1.10.0
-psycopg2==2.6.2
+psycopg2==2.7.3.2
 python-dotenv==0.3.0
 redis==2.10.5
 requests==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==0.8.10
 click==6.7
+celery==4.1.0
 fakeredis==0.8.2
 Flask==0.12
 Flask-CDN==1.5.3
@@ -17,7 +18,7 @@ gunicorn==19.6.0
 hashids==1.0.2
 httpretty==0.8.14
 itsdangerous==0.24
-git+https://github.com/mitsuhiko/jinja2@84f39ff5afd89760e1eff387ba4ce38e4a982977
+Jinja2==2.10
 limits==1.2.1
 Mako==1.0.6
 MarkupSafe==0.23


### PR DESCRIPTION
**Changes proposed in this pull request:**

* updating requirements.txt with the minimal new set of dependencies to build correctly
* adding settings to enable a celery results backend if needed in the future

**Any Additional Information**

Note that having the celery stuff in redis will create additional keys. For just messaging, the redis broker only adds a few extra keys under the _kombu prefix:

```
5) "_kombu.binding.celeryev"
7) "_kombu.binding.celery.pidbox"
8) "_kombu.binding.celery"
```

However if we add the results backend, it creates a new key for every result:

```
2) "celery-task-meta-74ee4017-5058-43e0-8c74-da7a05c0197b"
3) "celery-task-meta-a3c47ba1-df71-4263-914b-d5d86baa5512"
4) "celery-task-meta-d24029af-186b-48ee-b5a3-2eb32e25fcd4"
6) "celery-task-meta-19e004f5-a0a7-439d-8562-93771fb1556a"
```

This isn't a huge deal, because the keys expire by default after 1 day. However we may want to keep an eye on it. 