### PR TITLE
run celery task in a request_context.

### DIFF
--- a/formspree/users/views.py
+++ b/formspree/users/views.py
@@ -315,7 +315,7 @@ def stripe_webhook():
                 DB.session.add(user)
                 DB.session.commit()
                 g.log.info('Downgraded user from webhook.', account=user.email)
-                send_downgrade_email.delay(customer.email)
+                send_downgrade_email.delay(user.email)
         elif event['type'] == 'invoice.payment_failed':  # User payment failed
             customer_id = event['data']['object']['customer']
             customer = stripe.Customer.retrieve(customer_id)


### PR DESCRIPTION
SERVICE_URL is used to give the fake request_context awareness of the application url so url_for(_external=) can be used.

a structlog instance is created for each celery task as @app.before_request doesn't seem to be running for these fake request_contexts.